### PR TITLE
Make URI dropin compatible

### DIFF
--- a/lib/local_uri/uri.rb
+++ b/lib/local_uri/uri.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/module/delegation'
 
 module LocalUri
+  URI_CORE = URI
+
   class URI
 
     delegate(
@@ -16,7 +18,7 @@ module LocalUri
     attr_reader :uri
 
     def initialize(string)
-      @uri = ::URI.parse(string)
+      @uri = URI_CORE.parse(string.to_s)
     end
 
     def dup

--- a/lib/local_uri/uri.rb
+++ b/lib/local_uri/uri.rb
@@ -3,22 +3,16 @@ require 'active_support/core_ext/module/delegation'
 module LocalUri
   URI_CORE = URI
 
-  class URI
+  class URI < SimpleDelegator
 
-    delegate(
-      :to_s,
-      :scheme,
-      :scheme=,
-      :host,
-      :host=,
-      :path,
-      :path=,
-      to: :uri
-    )
     attr_reader :uri
 
     def initialize(string)
-      @uri = URI_CORE.parse(string.to_s)
+      @uri = super(URI_CORE.parse(string.to_s))
+    end
+
+    def empty?
+      @uri.to_s.empty?
     end
 
     def dup

--- a/lib/local_uri/version.rb
+++ b/lib/local_uri/version.rb
@@ -1,3 +1,3 @@
 module LocalUri
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/delegate_to_core_spec.rb
+++ b/spec/delegate_to_core_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper.rb'
+
+describe LocalUri::URI do
+  subject {URI('https://local.ch')}
+
+  it 'delegates to_s to URI core' do
+    expect(subject.to_s).to eq 'https://local.ch'
+  end
+
+  it 'delegates scheme to URI core' do
+    expect(subject.scheme).to eq 'https'
+  end
+
+  it 'delegates scheme= to URI core' do
+    subject.scheme = 'http'
+    expect(subject.to_s).to eq 'http://local.ch'
+  end
+
+  it 'delegates host to URI core' do
+    expect(subject.host).to eq 'local.ch'
+  end
+
+  it 'delegates host= to URI core' do
+    subject.host = 'google.com'
+    expect(subject.to_s).to eq 'https://google.com'
+  end
+
+  it 'delegates hostname to URI core' do
+    expect(subject.hostname).to eq 'local.ch'
+  end
+
+  it 'delegates hostname= to URI core' do
+    subject.hostname = 'google.com'
+    expect(subject.to_s).to eq 'https://google.com'
+  end
+
+  it 'delegates path to URI core' do
+    expect(subject.path).to eq ''
+  end
+
+  it 'delegates path= to URI core' do
+    subject.path = '/endpoint'
+    expect(subject.to_s).to eq 'https://local.ch/endpoint'
+  end
+
+  it 'delegates path to URI core' do
+    expect(subject.port).to eq 443
+  end
+
+  it 'delegates port= to URI core' do
+    subject.port = 3000
+    expect(subject.to_s).to eq 'https://local.ch:3000'
+  end
+
+  it 'delegates request_uri to URI core' do
+    expect(URI('http://local.ch/abc?test=123').request_uri).to eq '/abc?test=123'
+  end
+end

--- a/spec/delegate_to_core_spec.rb
+++ b/spec/delegate_to_core_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper.rb'
 
 describe LocalUri::URI do
-  subject {URI('https://local.ch')}
+  subject { URI('https://local.ch') }
 
   it 'delegates to_s to URI core' do
     expect(subject.to_s).to eq 'https://local.ch'
@@ -43,7 +43,7 @@ describe LocalUri::URI do
     expect(subject.to_s).to eq 'https://local.ch/endpoint'
   end
 
-  it 'delegates path to URI core' do
+  it 'delegates port to URI core' do
     expect(subject.port).to eq 443
   end
 

--- a/spec/empty_spec.rb
+++ b/spec/empty_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper.rb'
+
+describe LocalUri::URI do
+  it 'responds to empty?' do
+    expect(URI('https://local.ch').empty?).to eq false
+  end
+end

--- a/spec/initialization_spec.rb
+++ b/spec/initialization_spec.rb
@@ -4,4 +4,8 @@ describe LocalUri::URI do
   it 'initalizes' do
     URI('https://local.ch')
   end
+
+  it 'initalizes also when given a URI ruby core object' do
+    expect(URI(LocalUri::URI_CORE.parse('https://local.ch')).to_s).to eq('https://local.ch')
+  end
 end


### PR DESCRIPTION
Some gems use URI. This patch makes LocalUri drop in compatible.