### PR TITLE
Bugfix: No Question Mark for Empty Queries

### DIFF
--- a/lib/local_uri/query.rb
+++ b/lib/local_uri/query.rb
@@ -16,13 +16,13 @@ module LocalUri
 
     def merge(*args, &block)
       @uri.dup.tap do |uri|
-        uri.query_string = Rack::Utils.build_nested_query(parsed_query.merge(*args, &block))
+        uri.query_string = build_query_string(*args, &block)
       end
     end
 
     def merge!(*args, &block)
       @uri.tap do |uri|
-        uri.query_string = Rack::Utils.build_nested_query(parsed_query.merge(*args, &block))
+        uri.query_string = build_query_string(*args, &block)
       end
     end
 
@@ -30,6 +30,11 @@ module LocalUri
 
     def parsed_query
       Rack::Utils.parse_nested_query(@uri.query_string).with_indifferent_access
+    end
+
+    def build_query_string(*args, &block)
+      query_string = Rack::Utils.build_nested_query(parsed_query.merge(*args, &block))
+      query_string.empty? ? nil : query_string
     end
   end
 end

--- a/lib/local_uri/version.rb
+++ b/lib/local_uri/version.rb
@@ -1,3 +1,3 @@
 module LocalUri
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -19,6 +19,12 @@ describe LocalUri::URI do
         expect(subject.query.merge(id: 2).to_s).to eq 'https://local.ch?id=2'
       end
     end
+
+    context 'empty query params' do
+      it 'does not change the original url' do
+        expect(subject.query.merge({}).to_s).to eq 'https://local.ch'
+      end
+    end
   end
 
   context 'merge!' do
@@ -33,6 +39,12 @@ describe LocalUri::URI do
       it 'changes existing parameters' do
         subject.query.merge!(id: 2)
         expect(subject.to_s).to eq 'https://local.ch?id=2'
+      end
+    end
+
+    context 'empty query params' do
+      it 'does not change the original url' do
+        expect(subject.query.merge({}).to_s).to eq 'https://local.ch'
       end
     end
   end


### PR DESCRIPTION
### Before

Note the trailing question mark. :disappointed: 
```ruby
URI('https://local.ch').query.merge({}).to_s  # => 'https://local.ch?' 
```

### After

No more trailing question marks for empty query merges :smiley: 
```ruby
URI('https://local.ch').query.merge({}).to_s  # => 'https://local.ch' 
```

### TODO
 - [x] ~Did I increase the version?~ Yes, I did!