### PR TITLE
Upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           ruby-version: 2.6.6
       - name: Cache Ruby Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /.tmp/vendor/bundle
           key: ${{ runner.os }}-gems-latest-${{ hashFiles('**/Gemfile.lock', '**.*.gemspec') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           ruby-version: 2.6.6
       - name: Cache Ruby Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /.tmp/vendor/bundle
           key: ${{ runner.os }}-gems-latest-${{ hashFiles('**/Gemfile.lock', '**.*.gemspec') }}


### PR DESCRIPTION
The actions/cache@v1 and v2 are being deprecated February 1, 2025.

> :bulb: Upgrading to the recommended versions will not break your workflows.
>
> https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

Please merge this PR yourself if you are happy with the changes. :pray:

Official [deprecation announcement](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)
